### PR TITLE
Add chrome launching code to browser_launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dart:
   - dev
 
 dart_task:
-  # - test
+  - test
   - dartanalyzer: --fatal-infos --fatal-warnings .
 
 matrix:

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -14,13 +14,11 @@ const _linuxExecutable = 'google-chrome';
 const _macOSExecutable =
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const _windowsExecutable = r'Google\Chrome\Application\chrome.exe';
-var _windowsPrefixes = [
-  Platform.environment['LOCALAPPDATA'],
-  Platform.environment['PROGRAMFILES'],
-  Platform.environment['PROGRAMFILES(X86)']
-];
+const _windowsPrefixes = ['LOCALAPPDATA', 'PROGRAMFILES', 'PROGRAMFILES(X86)'];
 
 String get _executable {
+  final windowsPrefixes =
+      _windowsPrefixes.map((name) => Platform.environment[name]).toList();
   if (Platform.environment.containsKey(_chromeEnvironment)) {
     return Platform.environment[_chromeEnvironment];
   }
@@ -28,7 +26,7 @@ String get _executable {
   if (Platform.isMacOS) return _macOSExecutable;
   if (Platform.isWindows) {
     return p.join(
-        _windowsPrefixes.firstWhere((prefix) {
+        windowsPrefixes.firstWhere((prefix) {
           if (prefix == null) return false;
           final path = p.join(prefix, _windowsExecutable);
           return File(path).existsSync();
@@ -220,9 +218,7 @@ class ChromeError extends Error {
   ChromeError(this.details);
 
   @override
-  String toString() {
-    return 'ChromeError: $details';
-  }
+  String toString() => 'ChromeError: $details';
 }
 
 /// Returns a port that is probably, but not definitely, not in use.

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -65,14 +65,14 @@ class Chrome {
     List<String> urls, {
     String userDataDir,
     int remoteDebuggingPort,
-    bool disableBackgroundTimerThrottling = false,
-    bool disableExtensions = false,
-    bool disablePopupBlocking = false,
-    bool bwsi = false,
-    bool noFirstRun = false,
-    bool noDefaultBrowserCheck = false,
-    bool disableDefaultApps = false,
-    bool disableTranslate = false,
+    bool disableBackgroundTimerThrottling,
+    bool disableExtensions,
+    bool disablePopupBlocking,
+    bool bwsi,
+    bool noFirstRun,
+    bool noDefaultBrowserCheck,
+    bool disableDefaultApps,
+    bool disableTranslate,
   }) async {
     final port = remoteDebuggingPort == null || remoteDebuggingPort == 0
         ? await findUnusedPort()
@@ -115,14 +115,14 @@ class Chrome {
     List<String> urls, {
     String userDataDir,
     int remoteDebuggingPort,
-    bool disableBackgroundTimerThrottling = false,
-    bool disableExtensions = false,
-    bool disablePopupBlocking = false,
-    bool bwsi = false,
-    bool noFirstRun = false,
-    bool noDefaultBrowserCheck = false,
-    bool disableDefaultApps = false,
-    bool disableTranslate = false,
+    bool disableBackgroundTimerThrottling,
+    bool disableExtensions,
+    bool disablePopupBlocking,
+    bool bwsi,
+    bool noFirstRun,
+    bool noDefaultBrowserCheck,
+    bool disableDefaultApps,
+    bool disableTranslate,
   }) async {
     await _startProcess(
       urls,

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -65,14 +65,14 @@ class Chrome {
     List<String> urls, {
     String userDataDir,
     int remoteDebuggingPort,
-    bool disableBackgroundTimerThrottling,
-    bool disableExtensions,
-    bool disablePopupBlocking,
-    bool bwsi,
-    bool noFirstRun,
-    bool noDefaultBrowserCheck,
-    bool disableDefaultApps,
-    bool disableTranslate,
+    bool disableBackgroundTimerThrottling = false,
+    bool disableExtensions = false,
+    bool disablePopupBlocking = false,
+    bool bwsi = false,
+    bool noFirstRun = false,
+    bool noDefaultBrowserCheck = false,
+    bool disableDefaultApps = false,
+    bool disableTranslate = false,
   }) async {
     final port = remoteDebuggingPort == null || remoteDebuggingPort == 0
         ? await findUnusedPort()
@@ -115,14 +115,14 @@ class Chrome {
     List<String> urls, {
     String userDataDir,
     int remoteDebuggingPort,
-    bool disableBackgroundTimerThrottling,
-    bool disableExtensions,
-    bool disablePopupBlocking,
-    bool bwsi,
-    bool noFirstRun,
-    bool noDefaultBrowserCheck,
-    bool disableDefaultApps,
-    bool disableTranslate,
+    bool disableBackgroundTimerThrottling = false,
+    bool disableExtensions = false,
+    bool disablePopupBlocking = false,
+    bool bwsi = false,
+    bool noFirstRun = false,
+    bool noDefaultBrowserCheck = false,
+    bool disableDefaultApps = false,
+    bool disableTranslate = false,
   }) async {
     await _startProcess(
       urls,

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -15,7 +15,6 @@ const _linuxExecutable = 'google-chrome';
 const _macOSExecutable =
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const _windowsExecutable = r'Google\Chrome\Application\chrome.exe';
-const _windowsPrefixes = {'LOCALAPPDATA', 'PROGRAMFILES', 'PROGRAMFILES(X86)'};
 
 String get _executable {
   if (Platform.environment.containsKey(_chromeEnvironment)) {
@@ -24,8 +23,11 @@ String get _executable {
   if (Platform.isLinux) return _linuxExecutable;
   if (Platform.isMacOS) return _macOSExecutable;
   if (Platform.isWindows) {
-    final windowsPrefixes =
-        _windowsPrefixes.map((name) => Platform.environment[name]).toList();
+    final windowsPrefixes = [
+      Platform.environment['LOCALAPPDATA'],
+      Platform.environment['PROGRAMFILES'],
+      Platform.environment['PROGRAMFILES(X86)']
+    ];
     return p.join(
       windowsPrefixes.firstWhere((prefix) {
         if (prefix == null) return false;

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -1,3 +1,244 @@
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+const _chromeEnvironment = 'CHROME_EXECUTABLE';
+const _linuxExecutable = 'google-chrome';
+const _macOSExecutable =
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const _windowsExecutable = r'Google\Chrome\Application\chrome.exe';
+var _windowsPrefixes = [
+  Platform.environment['LOCALAPPDATA'],
+  Platform.environment['PROGRAMFILES'],
+  Platform.environment['PROGRAMFILES(X86)']
+];
+
+String get _executable {
+  if (Platform.environment.containsKey(_chromeEnvironment)) {
+    return Platform.environment[_chromeEnvironment];
+  }
+  if (Platform.isLinux) return _linuxExecutable;
+  if (Platform.isMacOS) return _macOSExecutable;
+  if (Platform.isWindows) {
+    return p.join(
+        _windowsPrefixes.firstWhere((prefix) {
+          if (prefix == null) return false;
+          final path = p.join(prefix, _windowsExecutable);
+          return File(path).existsSync();
+        }, orElse: () => '.'),
+        _windowsExecutable);
+  }
+  throw StateError('Unexpected platform type.');
+}
+
+var _currentCompleter = Completer<Chrome>();
+
+/// A class for managing an instance of Chrome.
+class Chrome {
+  Chrome._(
+    this.debugPort,
+    this.chromeConnection, {
+    Process process,
+  }) : _process = process;
+
+  final int debugPort;
+  final Process _process;
+  final ChromeConnection chromeConnection;
+
+  /// Connects to an instance of Chrome with an open debug port.
+  static Future<Chrome> fromExisting(int port) async =>
+      _connect(Chrome._(port, ChromeConnection('localhost', port)));
+
+  static Future<Chrome> get connectedInstance => _currentCompleter.future;
+
+  /// Starts Chrome with the given arguments and a specific port.
+  ///
+  /// Each url in [urls] will be loaded in a separate tab.
+  static Future<Chrome> startWithPort(
+    List<String> urls, {
+    String userDataDir,
+    int remoteDebuggingPort,
+    bool disableBackgroundTimerThrottling = false,
+    bool disableExtensions = false,
+    bool disablePopupBlocking = false,
+    bool bwsi = false,
+    bool noFirstRun = false,
+    bool noDefaultBrowserCheck = false,
+    bool disableDefaultApps = false,
+    bool disableTranslate = false,
+  }) async {
+    final port = remoteDebuggingPort == null || remoteDebuggingPort == 0
+        ? await findUnusedPort()
+        : remoteDebuggingPort;
+
+    final process = await _startProcess(
+      urls,
+      userDataDir: userDataDir,
+      remoteDebuggingPort: port,
+      disableBackgroundTimerThrottling: disableBackgroundTimerThrottling,
+      disableExtensions: disableExtensions,
+      disablePopupBlocking: disablePopupBlocking,
+      bwsi: bwsi,
+      noFirstRun: noFirstRun,
+      noDefaultBrowserCheck: noDefaultBrowserCheck,
+      disableDefaultApps: disableDefaultApps,
+      disableTranslate: disableTranslate,
+    );
+
+    // Wait until the DevTools are listening before trying to connect.
+    await process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .firstWhere((line) => line.startsWith('DevTools listening'))
+        .timeout(Duration(seconds: 60),
+            onTimeout: () =>
+                throw Exception('Unable to connect to Chrome DevTools.'));
+
+    return _connect(Chrome._(
+      port,
+      ChromeConnection('localhost', port),
+      process: process,
+    ));
+  }
+
+  /// Starts Chrome with the given arguments.
+  ///
+  /// Each url in [urls] will be loaded in a separate tab.
+  static Future<void> start(
+    List<String> urls, {
+    String userDataDir,
+    int remoteDebuggingPort,
+    bool disableBackgroundTimerThrottling = false,
+    bool disableExtensions = false,
+    bool disablePopupBlocking = false,
+    bool bwsi = false,
+    bool noFirstRun = false,
+    bool noDefaultBrowserCheck = false,
+    bool disableDefaultApps = false,
+    bool disableTranslate = false,
+  }) async {
+    await _startProcess(
+      urls,
+      userDataDir: userDataDir,
+      remoteDebuggingPort: remoteDebuggingPort,
+      disableBackgroundTimerThrottling: disableBackgroundTimerThrottling,
+      disableExtensions: disableExtensions,
+      disablePopupBlocking: disablePopupBlocking,
+      bwsi: bwsi,
+      noFirstRun: noFirstRun,
+      noDefaultBrowserCheck: noDefaultBrowserCheck,
+      disableDefaultApps: disableDefaultApps,
+      disableTranslate: disableTranslate,
+    );
+  }
+
+  static Future<Process> _startProcess(
+    List<String> urls, {
+    String userDataDir,
+    int remoteDebuggingPort,
+    bool disableBackgroundTimerThrottling = false,
+    bool disableExtensions = false,
+    bool disablePopupBlocking = false,
+    bool bwsi = false,
+    bool noFirstRun = false,
+    bool noDefaultBrowserCheck = false,
+    bool disableDefaultApps = false,
+    bool disableTranslate = false,
+  }) async {
+    final List<String> args = [];
+    if (userDataDir != null) {
+      args.add('--user-data-dir=$userDataDir');
+    }
+    if (remoteDebuggingPort != null) {
+      args.add('--remote-debugging-port=$remoteDebuggingPort');
+    }
+    if (disableBackgroundTimerThrottling) {
+      args.add('--disable-background-timer-throttling');
+    }
+    if (disableExtensions) {
+      args.add('--disable-extensions');
+    }
+    if (disablePopupBlocking) {
+      args.add('--disable-popup-blocking');
+    }
+    if (bwsi) {
+      args.add('--bwsi');
+    }
+    if (noFirstRun) {
+      args.add('--no-first-run');
+    }
+    if (noDefaultBrowserCheck) {
+      args.add('--no-default-browser-check');
+    }
+    if (disableDefaultApps) {
+      args.add('--disable-default-apps');
+    }
+    if (disableTranslate) {
+      args.add('--disable-translate');
+    }
+    args..addAll(urls);
+
+    final process = await Process.start(_executable, args);
+
+    return process;
+  }
+
+  static Future<Chrome> _connect(Chrome chrome) async {
+    if (_currentCompleter.isCompleted) {
+      throw ChromeError('Only one instance of chrome can be started.');
+    }
+    // The connection is lazy. Try a simple call to make sure the provided
+    // connection is valid.
+    try {
+      await chrome.chromeConnection.getTabs();
+    } catch (e) {
+      await chrome.close();
+      throw ChromeError(
+          'Unable to connect to Chrome debug port: ${chrome.debugPort}\n $e');
+    }
+    _currentCompleter.complete(chrome);
+    return chrome;
+  }
+
+  Future<void> close() async {
+    if (_currentCompleter.isCompleted) _currentCompleter = Completer<Chrome>();
+    chromeConnection.close();
+    _process?.kill();
+    await _process?.exitCode;
+  }
+}
+
+class ChromeError extends Error {
+  final String details;
+  ChromeError(this.details);
+
+  @override
+  String toString() {
+    return 'ChromeError: $details';
+  }
+}
+
+/// Returns a port that is probably, but not definitely, not in use.
+///
+/// This has a built-in race condition: another process may bind this port at
+/// any time after this call has returned.
+Future<int> findUnusedPort() async {
+  int port;
+  ServerSocket socket;
+  try {
+    socket =
+        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
+  } on SocketException {
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  }
+  port = socket.port;
+  await socket.close();
+  return port;
+}

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -112,9 +112,14 @@ class Chrome {
   /// Each url in [urls] will be loaded in a separate tab.
   static Future<void> start(
     List<String> urls, {
+    bool headless = false,
     List<String> chromeArgs = const [],
   }) async {
-    await _startProcess(urls, args: chromeArgs);
+    final List<String> args = chromeArgs;
+    if (headless) {
+      args.add('--headless');
+    }
+    await _startProcess(urls, args: args);
   }
 
   static Future<Process> _startProcess(

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -146,7 +146,16 @@ class Chrome {
     chromeConnection.close();
     _process?.kill(ProcessSignal.sigkill);
     await _process?.exitCode;
-    await _dataDir?.delete(recursive: true);
+    try {
+      // Chrome starts another process as soon as it dies that modifies the
+      // profile information. Give it some time before attempting to delete
+      // the directory.
+      await Future.delayed(Duration(milliseconds: 500));
+      await _dataDir?.delete(recursive: true);
+    } catch (_) {
+      // Silently fail if we can't clean up the profile information.
+      // It is a system tmp directory so it should get cleaned up eventually.
+    }
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
+  path: ^1.6.2
+  webkit_inspection_protocol: ^0.4.0
 
-dev_dependnecies:
+dev_dependencies:
   pedantic: ^1.5.0
+  test: ^1.0.0

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -73,21 +73,3 @@ void main() {
 }
 
 const _googleUrl = 'https://www.google.com/';
-
-/// Returns a port that is probably, but not definitely, not in use.
-///
-/// This has a built-in race condition: another process may bind this port at
-/// any time after this call has returned.
-Future<int> findUnusedPort() async {
-  int port;
-  ServerSocket socket;
-  try {
-    socket =
-        await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
-  } on SocketException {
-    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-  }
-  port = socket.port;
-  await socket.close();
-  return port;
-}

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -4,10 +4,8 @@
 
 @OnPlatform({'windows': Skip('appveyor is not setup to install Chrome')})
 import 'dart:async';
-import 'dart:io';
 
 import 'package:browser_launcher/src/chrome.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -15,21 +13,7 @@ void main() {
   Chrome chrome;
 
   Future<void> launchChromeWithDebugPort({int port}) async {
-    chrome = await Chrome.startWithDebugPort([_googleUrl],
-        debugPort: port,
-        chromeArgs: [
-          // When the DevTools has focus we don't want to slow down the application.
-          '--disable-background-timer-throttling',
-          // Since we are using a temp profile, disable features that slow the
-          // Chrome launch.
-          '--disable-extensions',
-          '--disable-popup-blocking',
-          '--bwsi',
-          '--no-first-run',
-          '--no-default-browser-check',
-          '--disable-default-apps',
-          '--disable-translate',
-        ]);
+    chrome = await Chrome.startWithDebugPort([_googleUrl], debugPort: port);
   }
 
   Future<void> launchChrome() async {

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:browser_launcher/src/chrome.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+void main() {
+  Chrome chrome;
+
+  Future<void> launchChromeWithDebugPort({int port}) async {
+    final dataDir = Directory(p.joinAll(
+        [Directory.current.path, '.dart_tool', 'webdev', 'chrome_profile']))
+      ..createSync(recursive: true);
+    chrome = await Chrome.startWithPort(
+      [_googleUrl],
+      userDataDir: dataDir.path,
+      remoteDebuggingPort: port,
+      disableBackgroundTimerThrottling: true,
+      disableExtensions: true,
+      disablePopupBlocking: true,
+      bwsi: true,
+      noFirstRun: true,
+      noDefaultBrowserCheck: true,
+      disableDefaultApps: true,
+      disableTranslate: true,
+    );
+  }
+
+  Future<void> launchChrome() async {
+    await Chrome.start([_googleUrl]);
+  }
+
+  tearDown(() async {
+    await chrome?.close();
+    chrome = null;
+  });
+
+  test('can launch chrome', () async {
+    await launchChrome();
+    expect(chrome, isNull);
+  }, skip: Platform.isWindows);
+
+  test('can launch chrome with debug port', () async {
+    await launchChromeWithDebugPort();
+    expect(chrome, isNotNull);
+  }, skip: Platform.isWindows);
+
+  test('debugger is working', () async {
+    await launchChromeWithDebugPort();
+    var tabs = await chrome.chromeConnection.getTabs();
+    expect(
+        tabs,
+        contains(const TypeMatcher<ChromeTab>()
+            .having((t) => t.url, 'url', _googleUrl)));
+  }, skip: Platform.isWindows);
+
+  test('uses open debug port if provided port is 0', () async {
+    await launchChromeWithDebugPort(port: 0);
+    expect(chrome.debugPort, isNot(equals(0)));
+  }, skip: Platform.isWindows);
+}
+
+const _googleUrl = 'http://www.google.com/';

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -44,12 +44,12 @@ void main() {
   test('can launch chrome', () async {
     await launchChrome();
     expect(chrome, isNull);
-  }, skip: Platform.isWindows);
+  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
 
   test('can launch chrome with debug port', () async {
     await launchChromeWithDebugPort();
     expect(chrome, isNotNull);
-  }, skip: Platform.isWindows);
+  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
 
   test('debugger is working', () async {
     await launchChromeWithDebugPort();
@@ -58,12 +58,12 @@ void main() {
         tabs,
         contains(const TypeMatcher<ChromeTab>()
             .having((t) => t.url, 'url', _googleUrl)));
-  }, skip: Platform.isWindows);
+  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
 
   test('uses open debug port if provided port is 0', () async {
     await launchChromeWithDebugPort(port: 0);
     expect(chrome.debugPort, isNot(equals(0)));
-  }, skip: Platform.isWindows);
+  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
 }
 
-const _googleUrl = 'http://www.google.com/';
+const _googleUrl = 'https://www.google.com/';

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@OnPlatform({'windows': Skip('appveyor is not setup to install Chrome')})
 import 'dart:async';
 import 'dart:io';
 
@@ -17,7 +18,7 @@ void main() {
     final dataDir = Directory(p.joinAll(
         [Directory.current.path, '.dart_tool', 'webdev', 'chrome_profile']))
       ..createSync(recursive: true);
-    chrome = await Chrome.startWithPort(
+    chrome = await Chrome.startWithDebugPort(
       [_googleUrl],
       userDataDir: dataDir.path,
       remoteDebuggingPort: port,
@@ -44,12 +45,12 @@ void main() {
   test('can launch chrome', () async {
     await launchChrome();
     expect(chrome, isNull);
-  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
+  });
 
   test('can launch chrome with debug port', () async {
     await launchChromeWithDebugPort();
     expect(chrome, isNotNull);
-  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
+  });
 
   test('debugger is working', () async {
     await launchChromeWithDebugPort();
@@ -58,12 +59,12 @@ void main() {
         tabs,
         contains(const TypeMatcher<ChromeTab>()
             .having((t) => t.url, 'url', _googleUrl)));
-  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
+  });
 
   test('uses open debug port if provided port is 0', () async {
     await launchChromeWithDebugPort(port: 0);
     expect(chrome.debugPort, isNot(equals(0)));
-  }, onPlatform: {'windows': Skip('appveyor is not setup to install Chrome')});
+  });
 }
 
 const _googleUrl = 'https://www.google.com/';

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -15,9 +15,6 @@ void main() {
   Chrome chrome;
 
   Future<void> launchChromeWithDebugPort({int port}) async {
-    final dataDir = Directory(p.joinAll(
-        [Directory.current.path, '.dart_tool', 'webdev', 'chrome_profile']))
-      ..createSync(recursive: true);
     chrome = await Chrome.startWithDebugPort([_googleUrl],
         debugPort: port,
         chromeArgs: [


### PR DESCRIPTION
Pulled code from https://github.com/dart-lang/webdev/blob/master/webdev/lib/src/serve/chrome.dart with some slight modifications like named parameters and a method to launch chrome without a debug port

Pulled test code from https://github.com/dart-lang/webdev/blob/master/webdev/test/serve/chrome_test.dart