### PR TITLE
Change min sdk and prepare for release 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.2.0
+  - 2.1.0-dev
   - dev
 
 dart_task:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.1.0-dev
+  - 2.1.2-dev.0.0
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- lower min sdk version to match Flutter stable
+
 ## 0.1.1
 
 - added example

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/browser_launcher
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
   path: ^1.6.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/browser_launcher
 
 environment:
-  sdk: '>=2.1.0-dev <3.0.0'
+  sdk: '>=2.1.2-dev.0.0 <3.0.0'
 
 dependencies:
   path: ^1.6.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: browser_launcher
 description: Provides a standardized way to launch web browsers for testing and tools.
 
-version: 0.1.1
+version: 0.1.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/browser_launcher


### PR DESCRIPTION
Until flutter stable is cut at dart 2.2.0, we need to lower browser_launcher's min sdk to match flutter stable. This is critical for devtools, as well, since devtools depends on browser_launcher.