### PR TITLE
Return process from start()

### DIFF
--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -113,11 +113,11 @@ class Chrome {
   /// Starts Chrome with the given arguments.
   ///
   /// Each url in [urls] will be loaded in a separate tab.
-  static Future<void> start(
+  static Future<Process> start(
     List<String> urls, {
     List<String> args = const [],
   }) async {
-    await _startProcess(urls, args: args);
+    return await _startProcess(urls, args: args);
   }
 
   static Future<Process> _startProcess(


### PR DESCRIPTION
Without this it's difficult to terminate the Chrome process you started (I'm trying to clean up in DevTools server integration tests).