### PR TITLE
Adding additional Chrome environment variables for executable resolution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.9
+
+ - Add support for Chrome executables in `CHROME_PATH`.
+
 ## 0.1.8
 
 - Log `STDERR` on Chrome launch failure.

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -9,15 +9,17 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
-const _chromeEnvironment = 'CHROME_EXECUTABLE';
+const _chromeEnvironments = ['CHROME_EXECUTABLE', 'CHROME_PATH'];
 const _linuxExecutable = 'google-chrome';
 const _macOSExecutable =
     '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const _windowsExecutable = r'Google\Chrome\Application\chrome.exe';
 
 String get _executable {
-  if (Platform.environment.containsKey(_chromeEnvironment)) {
-    return Platform.environment[_chromeEnvironment];
+  for (var chromeEnv in _chromeEnvironments) {
+    if (Platform.environment.containsKey(chromeEnv)) {
+      return Platform.environment[chromeEnv];
+    }
   }
   if (Platform.isLinux) return _linuxExecutable;
   if (Platform.isMacOS) return _macOSExecutable;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: browser_launcher
 description: Provides a standardized way to launch web browsers for testing and tools.
 
-version: 0.1.8
+version: 0.1.9
 
 homepage: https://github.com/dart-lang/browser_launcher
 


### PR DESCRIPTION
Currently browser_launcher.dart expects the Chrome exec to be in [`CHROME_EXECUTABLE`](https://github.com/dart-lang/browser_launcher/blob/master/lib/src/chrome.dart#L12), but our test bots store this in `CHROME_PATH`. A quick search in codesearch reveals both to be pretty common environment variables.

This'll be easier than modifying environment variables in the build system or from within the new suite of eval tests.