### PR TITLE
Fix internal CI test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.2-dev
 
 - Require Dart 2.17
+- Log errors from chrome
+- Allow tests to detect headless-only environment (for CI).
 
 ## 1.1.1
 

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
 
@@ -46,6 +47,8 @@ String get _executable {
 
 /// Manager for an instance of Chrome.
 class Chrome {
+  static final _logger = Logger('CHROME');
+
   Chrome._(
     this.debugPort,
     this.chromeConnection, {
@@ -119,16 +122,23 @@ class Chrome {
     // Wait until the DevTools are listening before trying to connect.
     final errorLines = <String>[];
     try {
-      await process.stderr
+      final stderr = process.stderr.asBroadcastStream();
+      stderr
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen(_logger.fine);
+
+      await stderr
           .transform(utf8.decoder)
           .transform(const LineSplitter())
           .firstWhere((line) {
         errorLines.add(line);
         return line.startsWith('DevTools listening');
       }).timeout(const Duration(seconds: 60));
-    } catch (_) {
+    } catch (e, s) {
+      _logger.severe('Unable to connect to Chrome DevTools', e, s);
       throw Exception(
-        'Unable to connect to Chrome DevTools.\n\n'
+        'Unable to connect to Chrome DevTools: $e.\n\n'
         'Chrome STDERR:\n${errorLines.join('\n')}',
       );
     }

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -47,7 +47,7 @@ String get _executable {
 
 /// Manager for an instance of Chrome.
 class Chrome {
-  static final _logger = Logger('CHROME');
+  static final _logger = Logger('BROWSER_LAUNCHER.CHROME');
 
   Chrome._(
     this.debugPort,
@@ -135,7 +135,7 @@ class Chrome {
         errorLines.add(line);
         return line.startsWith('DevTools listening');
       }).timeout(const Duration(seconds: 60));
-    } catch (e, s) {
+    } on TimeoutException catch (e, s) {
       _logger.severe('Unable to connect to Chrome DevTools', e, s);
       throw Exception(
         'Unable to connect to Chrome DevTools: $e.\n\n'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
+  logging: ^1.0.0
   path: ^1.8.0
   webkit_inspection_protocol: ^1.0.0
 

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -175,6 +175,8 @@ void main() {
                 );
                 await openTab(_chromeVersionUrl);
                 final wipConnection = await connectToTab(_chromeVersionUrl);
+                await wipConnection.debugger.enable();
+                await wipConnection.runtime.enable();
                 final result = await _evaluate(
                   wipConnection.page,
                   "document.getElementById('profile_path').textContent",

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -7,120 +7,91 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:browser_launcher/src/chrome.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+const _headlessOnlyEnvironment = 'HEADLESS_ONLY';
+
+bool get headlessOnlyEnvironment =>
+    Platform.environment[_headlessOnlyEnvironment] == 'true';
+
+void _configureLogging(bool verbose) {
+  Logger.root.level = verbose ? Level.ALL : Level.INFO;
+  Logger.root.onRecord.listen((record) {
+    print('${record.level.name}: ${record.time}: ${record.message}');
+  });
+}
 
 void main() {
   Chrome? chrome;
 
+  // Pass 'true' for debugging.
+  _configureLogging(false);
+
+  Future<ChromeTab?> getTab(String url) => chrome!.chromeConnection.getTab(
+        (t) => t.url.contains(url),
+        retryFor: const Duration(seconds: 5),
+      );
+
   Future<WipConnection> connectToTab(String url) async {
-    final tab =
-        await chrome!.chromeConnection.getTab((t) => t.url.contains(url));
+    final tab = await getTab(url);
     expect(tab, isNotNull);
     return tab!.connect();
   }
 
-  Future<void> openTab(String url) async {
-    await chrome!.chromeConnection.getUrl(_openTabUrl(url));
-  }
+  Future<HttpClientResponse> openTab(String url) =>
+      chrome!.chromeConnection.getUrl(_openTabUrl(url));
 
   Future<void> launchChromeWithDebugPort({
     int port = 0,
     String? userDataDir,
     bool signIn = false,
+    bool headless = false,
   }) async {
     chrome = await Chrome.startWithDebugPort(
       [_googleUrl],
       debugPort: port,
       userDataDir: userDataDir,
       signIn: signIn,
+      headless: headless,
     );
   }
 
-  Future<void> launchChrome() async {
-    await Chrome.start([_googleUrl]);
+  Future<void> launchChrome({bool headless = false}) async {
+    await Chrome.start([_googleUrl], args: [if (headless) '--headless']);
   }
 
-  group('chrome with temp data dir', () {
-    tearDown(() async {
-      await chrome?.close();
-      chrome = null;
-    });
-
-    test('can launch chrome', () async {
-      await launchChrome();
-      expect(chrome, isNull);
-    });
-
-    test('can launch chrome with debug port', () async {
-      await launchChromeWithDebugPort();
-      expect(chrome, isNotNull);
-    });
-
-    test('has a working debugger', () async {
-      await launchChromeWithDebugPort();
-      final tabs = await chrome!.chromeConnection.getTabs();
-      expect(
-        tabs,
-        contains(
-          const TypeMatcher<ChromeTab>()
-              .having((t) => t.url, 'url', _googleUrl),
-        ),
-      );
-    });
-
-    test('uses open debug port if provided port is 0', () async {
-      await launchChromeWithDebugPort();
-      expect(chrome!.debugPort, isNot(equals(0)));
-    });
-
-    test('can provide a specific debug port', () async {
-      final port = await findUnusedPort();
-      await launchChromeWithDebugPort(port: port);
-      expect(chrome!.debugPort, port);
-    });
-  });
-
-  group('chrome with user data dir', () {
-    late Directory dataDir;
-
-    for (var signIn in [false, true]) {
-      group('and signIn = $signIn', () {
-        setUp(() {
-          dataDir = Directory.systemTemp.createTempSync(_userDataDirName);
-        });
-
+  final headlessModes = headlessOnlyEnvironment ? [true] : [true, false];
+  for (var headless in headlessModes) {
+    group('(headless: $headless)', () {
+      group('chrome with temp data dir', () {
         tearDown(() async {
           await chrome?.close();
           chrome = null;
-
-          var attempts = 0;
-          while (true) {
-            try {
-              attempts++;
-              await Future<void>.delayed(const Duration(milliseconds: 100));
-              dataDir.deleteSync(recursive: true);
-              break;
-            } catch (_) {
-              if (attempts > 3) rethrow;
-            }
-          }
         });
 
-        test('can launch with debug port', () async {
-          await launchChromeWithDebugPort(
-            userDataDir: dataDir.path,
-            signIn: signIn,
-          );
+        test('can launch chrome', () async {
+          await launchChrome(headless: headless);
+          expect(chrome, isNull);
+        });
+
+        test('can launch chrome with debug port', () async {
+          await launchChromeWithDebugPort(headless: headless);
           expect(chrome, isNotNull);
         });
 
         test('has a working debugger', () async {
-          await launchChromeWithDebugPort(
-            userDataDir: dataDir.path,
-            signIn: signIn,
-          );
-          final tabs = await chrome!.chromeConnection.getTabs();
+          await launchChromeWithDebugPort(headless: headless);
+
+          const waitMilliseconds = Duration(milliseconds: 1000);
+          const retryMilliseconds = Duration(milliseconds: 1000);
+
+          // Wait for debugger to start.
+          await Future<dynamic>.delayed(waitMilliseconds);
+
+          final tabs = await chrome!.chromeConnection
+              .getTabs(retryFor: retryMilliseconds);
           expect(
             tabs,
             contains(
@@ -130,39 +101,116 @@ void main() {
           );
         });
 
-        test('has correct profile path', () async {
-          await launchChromeWithDebugPort(
-            userDataDir: dataDir.path,
-            signIn: signIn,
-          );
-          await openTab(_chromeVersionUrl);
+        test('uses open debug port if provided port is 0', () async {
+          await launchChromeWithDebugPort(headless: headless);
+          expect(chrome!.debugPort, isNot(equals(0)));
+        });
 
-          final wipConnection = await connectToTab(_chromeVersionUrl);
-          final result = await _evaluateExpression(
-            wipConnection.page,
-            "document.getElementById('profile_path').textContent",
-          );
-
-          expect(result, contains(_userDataDirName));
+        test('can provide a specific debug port', () async {
+          final port = await findUnusedPort();
+          await launchChromeWithDebugPort(port: port, headless: headless);
+          expect(chrome!.debugPort, port);
         });
       });
-    }
-  });
+
+      group('chrome with user data dir', () {
+        late Directory dataDir;
+        const waitMilliseconds = Duration(milliseconds: 100);
+
+        for (var signIn in [false, true]) {
+          group('and signIn = $signIn', () {
+            setUp(() {
+              dataDir = Directory.systemTemp.createTempSync(_userDataDirName);
+            });
+
+            tearDown(() async {
+              await chrome?.close();
+              chrome = null;
+
+              var attempts = 0;
+              while (true) {
+                try {
+                  attempts++;
+                  await Future<dynamic>.delayed(waitMilliseconds);
+                  dataDir.deleteSync(recursive: true);
+                  break;
+                } catch (_) {
+                  if (attempts > 3) rethrow;
+                }
+              }
+            });
+
+            test('can launch with debug port', () async {
+              await launchChromeWithDebugPort(
+                userDataDir: dataDir.path,
+                signIn: signIn,
+                headless: headless,
+              );
+              expect(chrome, isNotNull);
+            });
+
+            test('has a working debugger', () async {
+              await launchChromeWithDebugPort(
+                userDataDir: dataDir.path,
+                signIn: signIn,
+                headless: headless,
+              );
+              final tabs = await chrome!.chromeConnection.getTabs();
+              expect(
+                tabs,
+                contains(
+                  const TypeMatcher<ChromeTab>()
+                      .having((t) => t.url, 'url', _googleUrl),
+                ),
+              );
+            });
+
+            test(
+              'has correct profile path',
+              () async {
+                await launchChromeWithDebugPort(
+                  userDataDir: dataDir.path,
+                  signIn: signIn,
+                  headless: headless,
+                );
+                await openTab(_chromeVersionUrl);
+                final wipConnection = await connectToTab(_chromeVersionUrl);
+                final result = await _evaluate(
+                  wipConnection.page,
+                  "document.getElementById('profile_path').textContent",
+                );
+                expect(result, contains(_userDataDirName));
+              },
+              skip: headless, // headless mode does not allow chrome: urls.
+            );
+          });
+        }
+      });
+    });
+  }
 }
 
 String _openTabUrl(String url) => '/json/new?$url';
 
-Future<String> _evaluateExpression(WipPage page, String expression) async {
-  var result = '';
-  while (result.isEmpty) {
-    await Future<void>.delayed(const Duration(milliseconds: 100));
-    final wipResponse = await page.sendCommand(
-      'Runtime.evaluate',
-      params: {'expression': expression},
-    );
-    final response = wipResponse.json['result'] as Map<String, dynamic>;
-    final value = (response['result'] as Map<String, dynamic>)['value'];
-    result = (value != null && value is String) ? value : '';
+Future<String?> _evaluate(WipPage page, String expression) async {
+  String? result;
+  const stopInMilliseconds = Duration(milliseconds: 1000);
+  const waitMilliseconds = Duration(milliseconds: 100);
+  final stopTime = DateTime.now().add(stopInMilliseconds);
+
+  while (result == null && DateTime.now().isBefore(stopTime)) {
+    await Future<dynamic>.delayed(waitMilliseconds);
+    try {
+      final wipResponse = await page.sendCommand(
+        'Runtime.evaluate',
+        params: {'expression': expression},
+      );
+      final response = wipResponse.json['result'] as Map<String, dynamic>;
+      final value = (response['result'] as Map<String, dynamic>)['value'];
+      result = value?.toString();
+    } catch (_) {
+      return null;
+    }
   }
   return result;
 }

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -194,9 +194,9 @@ String _openTabUrl(String url) => '/json/new?$url';
 
 Future<String?> _evaluate(WipPage page, String expression) async {
   String? result;
-  const stopInMilliseconds = Duration(milliseconds: 1000);
+  const stopInSeconds = Duration(seconds: 5);
   const waitMilliseconds = Duration(milliseconds: 100);
-  final stopTime = DateTime.now().add(stopInMilliseconds);
+  final stopTime = DateTime.now().add(stopInSeconds);
 
   while (result == null && DateTime.now().isBefore(stopTime)) {
     await Future<dynamic>.delayed(waitMilliseconds);

--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -34,6 +34,10 @@ void main() {
         retryFor: const Duration(seconds: 5),
       );
 
+  Future<List<ChromeTab>?> getTabs() => chrome!.chromeConnection.getTabs(
+        retryFor: const Duration(seconds: 5),
+      );
+
   Future<WipConnection> connectToTab(String url) async {
     final tab = await getTab(url);
     expect(tab, isNotNull);
@@ -62,7 +66,11 @@ void main() {
     await Chrome.start([_googleUrl], args: [if (headless) '--headless']);
   }
 
-  final headlessModes = headlessOnlyEnvironment ? [true] : [true, false];
+  final headlessModes = [
+    true,
+    if (!headlessOnlyEnvironment) false,
+  ];
+
   for (var headless in headlessModes) {
     group('(headless: $headless)', () {
       group('chrome with temp data dir', () {
@@ -83,15 +91,7 @@ void main() {
 
         test('has a working debugger', () async {
           await launchChromeWithDebugPort(headless: headless);
-
-          const waitMilliseconds = Duration(milliseconds: 1000);
-          const retryMilliseconds = Duration(milliseconds: 1000);
-
-          // Wait for debugger to start.
-          await Future<dynamic>.delayed(waitMilliseconds);
-
-          final tabs = await chrome!.chromeConnection
-              .getTabs(retryFor: retryMilliseconds);
+          final tabs = await getTabs();
           expect(
             tabs,
             contains(
@@ -155,7 +155,7 @@ void main() {
                 signIn: signIn,
                 headless: headless,
               );
-              final tabs = await chrome!.chromeConnection.getTabs();
+              final tabs = await getTabs();
               expect(
                 tabs,
                 contains(


### PR DESCRIPTION
Chrome
- Add error logging to chrome launcher

Tests
- Add environment variable to detect headless-only mode (run by some CI)
- Run all tests in headless mode, if compatible
- Run all tests in normal mode if headless-only mode  is not detected
- Add waits and retries for some operations

Closes: https://github.com/dart-lang/tools/issues/745