### PR TITLE
Disable failing `chrome_test`

### DIFF
--- a/test/chrome_test.dart
+++ b/test/chrome_test.dart
@@ -183,7 +183,9 @@ void main() {
                 );
                 expect(result, contains(_userDataDirName));
               },
-              skip: headless, // headless mode does not allow chrome: urls.
+              // Note: When re-enabling, skip for headless mode because headless
+              // mode does not allow chrome: urls.
+              skip: 'https://github.com/dart-lang/sdk/issues/52357',
             );
           });
         }


### PR DESCRIPTION
Fixes https://github.com/dart-lang/tools/issues/746

Opened https://github.com/dart-lang/sdk/issues/52357 for the issue preventing us from opening `chrome:` URLs with HTTPClient.
