### PR TITLE
Add extra flags to disable throttling behavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Require Dart 3.0
 - Log errors from chrome
 - Allow tests to detect headless-only environment (for CI).
+- Add extra flags that may help disable additional throttling in background tabs
 
 ## 1.1.1
 

--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -102,6 +102,8 @@ class Chrome {
       '--remote-debugging-port=$port',
       // When the DevTools has focus we don't want to slow down the application.
       '--disable-background-timer-throttling',
+      '--disable-blink-features=TimerThrottlingForBackgroundTabs',
+      '--disable-features=IntensiveWakeUpThrottling',
       // Since we are using a temp profile, disable features that slow the
       // Chrome launch.
       if (!signIn) '--disable-extensions',


### PR DESCRIPTION
Add extra flags to disable throttling behavior.
    
These flags [were added in our internal SDK test infrastructure][1] and they
helped reduce flaky timeout behavior in the past. It's very likely that
these and the `--disable-background-timer-throttling` flag that's
already here have some overlap, though.
    
I have not been able to find much documentation about whether they do
overlap, so I was inclined to try to add these by default and
assess the effect in our CI.

Thoughts?
    
[1]: https://dart-review.googlesource.com/c/sdk/+/325780/2/pkg/test_runner/lib/src/browser_controller.dart

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
