### PR TITLE
Add --use-mock-keychain to Chrome args

### DIFF
--- a/lib/src/chrome.dart
+++ b/lib/src/chrome.dart
@@ -114,6 +114,10 @@ class Chrome {
       '--disable-default-apps',
       '--disable-translate',
       '--start-maximized',
+      // When running on MacOS, Chrome may open system dialogs requesting
+      // credentials. This uses a mock keychain to avoid that dialog from
+      // blocking.
+      '--use-mock-keychain',
     ];
     if (headless) {
       args.add('--headless');


### PR DESCRIPTION
Bug: https://github.com/dart-lang/sdk/issues/56519

Rolling the Chrome version in Dart CI to 128.0.6613.36 results in a system dialog requesting Chrome to use the keychain in MacOS. This then results in timeouts due to it being blocking. Instead, use a mock keychain.